### PR TITLE
feat: add apple configuration, don't know if it works

### DIFF
--- a/src/gos/settings.py
+++ b/src/gos/settings.py
@@ -61,9 +61,7 @@ INSTALLED_APPS += [
     # 'allauth.usersessions',
     "allauth.socialaccount",
     "allauth.socialaccount.providers.google",
-    # TODO: add apple after google works
-    #'allauth.socialaccount.providers.apple',
-    # https://docs.allauth.org/en/latest/socialaccount/providers/apple.html
+    'allauth.socialaccount.providers.apple',
     # </social auth>
 ]
 # original apps
@@ -216,4 +214,23 @@ SOCIALACCOUNT_PROVIDERS = {
         "OAUTH_PKCE_ENABLED": True,
         "FETCH_USERINFO": False,
     },
+    "apple": {
+        "APPS": [{
+            "client_id": env.str(
+                    "DJANGO_SOCIALACCOUNT_APPLE_CLIENT_ID", default=""
+                ),
+            "secret": env.str(
+                    "DJANGO_SOCIALACCOUNT_APPLE_KEY_ID", default=""
+                ),
+            "key": env.str(
+                    "DJANGO_SOCIALACCOUNT_APPLE_APP_ID", default=""
+                ),
+            "settings": {
+                "certificate_key": env.str(
+                    "DJANGO_SOCIALACCOUNT_APPLE_CERTIFICATE_KEY", default=""
+                ).replace(r"\n", "\n"),
+
+            }
+        }]
+    }
 }


### PR DESCRIPTION
This worked locally with an id_token I got from apple login. 
url:
`http://127.0.0.1:8000/auth/provider/token`
Request data:
```
{
  'provider': 'apple', 
  'process': 'login', 
  'token':
     {
       'client_id': 'com.mdaizovi.gameofskate',
       'id_token':'MY ID TOKEN'
    }
}
```

Response included:
```
{"status": 200, "data": {"user": {"id": 10, "display": "olddirtyspatula", "has_usable_password": false, "email": "<REDACTED>", "username": "olddirtyspatula"}, "methods": []}, "meta": {"is_authenticated": true, "session_token": "c8rs4v7hsiniqhtz5aj8cms3jnjq5r2s"}}
```